### PR TITLE
Paginação e endpoint para retorna um administrador da conab.

### DIFF
--- a/app/Http/Controllers/AdminConabController.php
+++ b/app/Http/Controllers/AdminConabController.php
@@ -19,8 +19,11 @@ class AdminConabController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $users = User::where('user_type', 'ADMIN_CONAB')->where('id', '<>', $user->id)->get();
-        return $users;
+        $admins = User::with('phones')->where([
+            ['user_type', '=', 'ADMIN_CONAB'],
+            ['id', '<>', $user->id]
+        ])->paginate(5);
+        return response($admins, 200);
     }
 
     /**

--- a/app/Http/Controllers/AdminConabController.php
+++ b/app/Http/Controllers/AdminConabController.php
@@ -24,6 +24,16 @@ class AdminConabController extends Controller
     }
 
     /**
+     * @param int $id
+     * @return \Illuminate\Http\Response
+     */
+     public function show($id)
+     {
+         $admin = User::with('phones')->findOrFail($id);
+        return response($admin, 200);
+     }
+
+    /**
      * Store a newly created resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
@@ -54,7 +64,6 @@ class AdminConabController extends Controller
      * Update the specified resource in storage.
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request)

--- a/app/Http/Controllers/AdminConabController.php
+++ b/app/Http/Controllers/AdminConabController.php
@@ -54,6 +54,7 @@ class AdminConabController extends Controller
 
         $user = new User();
         $user->fill($data);
+        $user->profile_picture = "https://ui-avatars.com/api/?name=" . $data['name'];
         $user->password = $data['cpf'];
         $user->user_type = 'ADMIN_CONAB';
         $user->save();

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ Route::middleware('auth:api')->group(function () {
         return 'hello';
     });
     Route::get('/conab/admins', 'AdminConabController@index');
+    Route::get('/conab/admins/{id}', 'AdminConabController@show');
     Route::post('/conab/admins', 'AdminConabController@store');
     Route::put('/conab/admins', 'AdminConabController@update');
     Route::delete('/conab/admins/{id}', 'AdminConabController@destroy');

--- a/tests/Feature/AdminConabControllerTest.php
+++ b/tests/Feature/AdminConabControllerTest.php
@@ -19,9 +19,18 @@ class AdminConabControllerTest extends TestCase
     {
         // Create fake users
         factory(User::class, 3)->create(['user_type' => 'ADMIN_CONAB']);
-        $authenticatedUser = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
-        $response = $this->actingAs($authenticatedUser, 'api')->getJson('/api/conab/admins');
+        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
+        $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins');
         $response->assertOK()->assertJsonCount(3);
+    }
+
+     /** @test */
+    public function should_return_one_admin()
+    {
+        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
+        $admin = factory(User::class)->create(['name' => 'admin', 'user_type' => 'ADMIN_CONAB']);
+        $response = $this->actingAs($user, 'api')->getJson("/api/conab/admins/$admin->id");
+        $response->assertOK()->assertJsonFragment(['name' => 'admin']);
     }
 
     /** @test */
@@ -32,16 +41,16 @@ class AdminConabControllerTest extends TestCase
         factory(User::class)->create(['user_type' => 'CUSTOMER']);
         factory(User::class)->create(['user_type' => 'ADMIN_COOP']);
 
-        $authenticatedUser = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
-        $response = $this->actingAs($authenticatedUser, 'api')->getJson('/api/conab/admins');
+        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
+        $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins');
         $response->assertOK()->assertJsonCount(1);
     }
 
     /** @test */
     public function should_return_an_empty_list_of_admins()
     {
-        $authenticatedUser = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
-        $response = $this->actingAs($authenticatedUser, 'api')->getJson('/api/conab/admins');
+        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
+        $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins');
         $response->assertOK()->assertJsonCount(0);
     }
 

--- a/tests/Feature/AdminConabControllerTest.php
+++ b/tests/Feature/AdminConabControllerTest.php
@@ -21,17 +21,10 @@ class AdminConabControllerTest extends TestCase
         factory(User::class, 3)->create(['user_type' => 'ADMIN_CONAB']);
         $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
         $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins');
-        $response->assertOK()->assertJsonCount(3);
+        $response->assertOK();
+        $this->assertCount(3, $response['data']);
     }
 
-     /** @test */
-    public function should_return_one_admin()
-    {
-        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
-        $admin = factory(User::class)->create(['name' => 'admin', 'user_type' => 'ADMIN_CONAB']);
-        $response = $this->actingAs($user, 'api')->getJson("/api/conab/admins/$admin->id");
-        $response->assertOK()->assertJsonFragment(['name' => 'admin']);
-    }
 
     /** @test */
     public function should_return_only_admins()
@@ -43,7 +36,8 @@ class AdminConabControllerTest extends TestCase
 
         $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
         $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins');
-        $response->assertOK()->assertJsonCount(1);
+        $response->assertOK();
+        $this->assertCount(1, $response['data']);
     }
 
     /** @test */
@@ -51,7 +45,32 @@ class AdminConabControllerTest extends TestCase
     {
         $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
         $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins');
-        $response->assertOK()->assertJsonCount(0);
+        $response->assertOK();
+        $this->assertCount(0, $response['data']);
+    }
+
+    /** @test */
+    public function should_paginate_each_5_admins()
+    {
+        // Create fake users
+        factory(User::class, 6)->create(['user_type' => 'ADMIN_CONAB']);
+        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
+        $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins?page=1');
+        $response->assertOK();
+        $this->assertCount(5, $response['data']);
+
+        $response = $this->actingAs($user, 'api')->getJson('/api/conab/admins?page=2');
+        $response->assertOK();
+        $this->assertCount(1, $response['data']);
+    }
+
+    /** @test */
+    public function should_return_one_admin()
+    {
+        $user = factory(User::class)->create(['user_type' => 'ADMIN_CONAB']);
+        $admin = factory(User::class)->create(['name' => 'admin', 'user_type' => 'ADMIN_CONAB']);
+        $response = $this->actingAs($user, 'api')->getJson("/api/conab/admins/$admin->id");
+        $response->assertOK()->assertJsonFragment(['name' => 'admin']);
     }
 
     /** @test */


### PR DESCRIPTION
## Descrição :pencil:
No PR de gerenciamento de administradores da conab, eu tinha esquecido de adicionar tanto a paginação que o frontend precisava quanto um endpoint especifico para retornar apenas um administrador. Além disso coloquei no retorno dos administradores os telefones, pq no frontend também tava faltando.

**Issues :pushpin:**
#40 #37 

## Informações adicionais
>Marque se alguma dessas opções foram adicionadas/desenvolvidas

- [ ] Nova dependência :heavy_plus_sign:
- [ ] Dependência removida :heavy_minus_sign:
- [x] Testes unitários ou de integração :white_check_mark:
- [ ] Nova migração para o Banco de Dados :card_file_box:
- [ ] Alteração no gitignore :see_no_evil:
- [x] Refatoração de código :recycle:
