### PR TITLE
Tipo de $code

### DIFF
--- a/database/migrations/2020_11_23_132029_alter-code-column-type.php
+++ b/database/migrations/2020_11_23_132029_alter-code-column-type.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AlterColumnTokenToCode extends Migration
+class AlterCodeColumnType extends Migration
 {
     /**
      * Run the migrations.
@@ -14,12 +14,9 @@ class AlterColumnTokenToCode extends Migration
     public function up()
     {
         Schema::table('password_resets', function (Blueprint $table) {
-            $table->dropColumn('token');
+            $table->integer('code')->change();
         });
 
-        Schema::table('password_resets', function (Blueprint $table) {
-            $table->string('code')->nullable();
-        });
     }
 
     /**
@@ -30,11 +27,8 @@ class AlterColumnTokenToCode extends Migration
     public function down()
     {
         Schema::table('password_resets', function (Blueprint $table) {
-            $table->dropColumn('code');
+            $table->string('code')->change();
         });
 
-        Schema::table('password_resets', function (Blueprint $table) {
-            $table->string('token')->nullable();
-        });
     }
 }


### PR DESCRIPTION
## Descrição :pencil:
Corrige o erro do tipo da variavel $code.

**Issues :pushpin:**
#82 

## Informações adicionais
Tive que alterar a migração "2020_11_12_133358_alter_column_token_to_code", pq não estava sendo possível efetuar o rollback.

- [ ] Nova dependência :heavy_plus_sign:
- [ ] Dependência removida :heavy_minus_sign:
- [ ] Testes unitários ou de integração :white_check_mark:
- [ ] Nova migração para o Banco de Dados :card_file_box:
- [ ] Alteração no gitignore :see_no_evil:
- [ ] Refatoração de código :recycle:
